### PR TITLE
Strip leading < and trailing > from messageID and parentMessageID

### DIFF
--- a/cmd/groupsio/groupsio.go
+++ b/cmd/groupsio/groupsio.go
@@ -1320,6 +1320,7 @@ func (j *DSGroupsio) GetModelData(ctx *shared.Ctx, docs []interface{}) (data map
 	for _, iDoc := range docs {
 		doc, _ := iDoc.(map[string]interface{})
 		sourceMessageID, _ := doc["Message-ID"].(string)
+		sourceMessageID = strings.TrimRight(strings.TrimLeft(sourceMessageID, "<"), ">")
 		messageID, err = insights.GenerateEmailMessageID(groupURL, source, sourceMessageID)
 		// shared.Printf("insights.GenerateEmailMessageID(%s,%s,%s) -> %s\n", groupURL, source, sourceMessageID, messageID)
 		if err != nil {
@@ -1327,6 +1328,7 @@ func (j *DSGroupsio) GetModelData(ctx *shared.Ctx, docs []interface{}) (data map
 			return
 		}
 		parentSourceMessageID, ok := doc["parent_message_id"].(string)
+		parentSourceMessageID = strings.TrimRight(strings.TrimLeft(parentSourceMessageID, "<"), ">")
 		parentMessageID := ""
 		if ok && parentSourceMessageID != "" {
 			parentMessageID, err = insights.GenerateEmailMessageID(groupURL, source, parentSourceMessageID)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/LF-Engineering/insights-datasource-shared v1.4.2-0.20220309073146-6f42257b2791
-	github.com/LF-Engineering/lfx-event-schema v0.1.9-0.20220310122101-d07e9aca0360
+	github.com/LF-Engineering/lfx-event-schema v0.1.10-0.20220310155104-8f242e656a87
 	github.com/aws/aws-lambda-go v1.28.0
 	github.com/aws/aws-sdk-go v1.42.24
 	github.com/json-iterator/go v1.1.12

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/LF-Engineering/insights-datasource-shared v1.4.2-0.20220309073146-6f42257b2791
-	github.com/LF-Engineering/lfx-event-schema v0.1.9-0.20220309224940-67adf60a9f3b
+	github.com/LF-Engineering/lfx-event-schema v0.1.9-0.20220310122101-d07e9aca0360
 	github.com/aws/aws-lambda-go v1.28.0
 	github.com/aws/aws-sdk-go v1.42.24
 	github.com/json-iterator/go v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/LF-Engineering/lfx-event-schema v0.1.9-0.20220303123456-81187090092a 
 github.com/LF-Engineering/lfx-event-schema v0.1.9-0.20220303123456-81187090092a/go.mod h1:GvEBmXvYGafFRIpZ6I0G5Ss4jsmkBNptLJIasLClXu8=
 github.com/LF-Engineering/lfx-event-schema v0.1.9-0.20220309224940-67adf60a9f3b h1:qFpaYdxhWUOzWdTJTNNLbIfqGyMxQJEIFaGmQtr835M=
 github.com/LF-Engineering/lfx-event-schema v0.1.9-0.20220309224940-67adf60a9f3b/go.mod h1:GvEBmXvYGafFRIpZ6I0G5Ss4jsmkBNptLJIasLClXu8=
+github.com/LF-Engineering/lfx-event-schema v0.1.9-0.20220310122101-d07e9aca0360 h1:eMeaqFqZMKvQ/Zu36nVW5kFGxYH2Aq+gVUpGHqZcTUw=
+github.com/LF-Engineering/lfx-event-schema v0.1.9-0.20220310122101-d07e9aca0360/go.mod h1:GvEBmXvYGafFRIpZ6I0G5Ss4jsmkBNptLJIasLClXu8=
 github.com/alecthomas/jsonschema v0.0.0-20210920000243-787cd8204a0d/go.mod h1:/n6+1/DWPltRLWL/VKyUxg6tzsl5kHUCcraimt4vr60=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/LF-Engineering/lfx-event-schema v0.1.9-0.20220309224940-67adf60a9f3b 
 github.com/LF-Engineering/lfx-event-schema v0.1.9-0.20220309224940-67adf60a9f3b/go.mod h1:GvEBmXvYGafFRIpZ6I0G5Ss4jsmkBNptLJIasLClXu8=
 github.com/LF-Engineering/lfx-event-schema v0.1.9-0.20220310122101-d07e9aca0360 h1:eMeaqFqZMKvQ/Zu36nVW5kFGxYH2Aq+gVUpGHqZcTUw=
 github.com/LF-Engineering/lfx-event-schema v0.1.9-0.20220310122101-d07e9aca0360/go.mod h1:GvEBmXvYGafFRIpZ6I0G5Ss4jsmkBNptLJIasLClXu8=
+github.com/LF-Engineering/lfx-event-schema v0.1.10-0.20220310155104-8f242e656a87 h1:9p5ZzIC5KZC735477lzeL4kB1qqElCyEd0b4rFj0tAM=
+github.com/LF-Engineering/lfx-event-schema v0.1.10-0.20220310155104-8f242e656a87/go.mod h1:GvEBmXvYGafFRIpZ6I0G5Ss4jsmkBNptLJIasLClXu8=
 github.com/alecthomas/jsonschema v0.0.0-20210920000243-787cd8204a0d/go.mod h1:/n6+1/DWPltRLWL/VKyUxg6tzsl5kHUCcraimt4vr60=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=


### PR DESCRIPTION
This is requested by @priyankakale15 

Signed-off-by: Łukasz Gryglicki <lgryglicki@cncf.io>